### PR TITLE
Upgrading pg-promise version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "cuid": "*",
     "lie": "*",
-    "pg-promise": "^2.1.0"
+    "pg-promise": "^4.3.3"
   },
   "devDependencies": {
     "chai": "^3.3.0",


### PR DESCRIPTION
2.1.0 is too old at this point, current one is 4.3.3

Among the most important things, support for Node.js 6.x
